### PR TITLE
Set minimum version to iOS 9

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -1,4 +1,5 @@
 target 'sampleapp-ios-swift' do
+  platform :ios, '9.0'
   use_frameworks!
 
   pod 'MobileCenter'


### PR DESCRIPTION
Just specify the iOS min version, it's default to 10.3 but MC SDK accept 8.0 and VSMobileCenterExtensions accept 9.0. So it's now set to 9.0 in Podfile. 